### PR TITLE
Disable mutex if mutex does not exists

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,6 +4,4 @@ MRuby::Gem::Specification.new('mruby-delayer') do |spec|
   spec.version     = '0.0.2'
   spec.summary     = %q{Delay the processing}
   spec.description = %q{Delay the processing}
-  
-  spec.add_dependency('mruby-thread', :github => 'mattn/mruby-thread')
 end

--- a/mrblib/delayer/extend.rb
+++ b/mrblib/delayer/extend.rb
@@ -5,6 +5,14 @@ module Delayer
     attr_accessor :expire
     attr_reader :exception
 
+    unless const_defined?(:Mutex)
+      class Mutex
+        def synchronize
+          yield
+        end
+      end
+    end
+
     def self.extended(klass)
       klass.class_eval do
         @first_pointer = @last_pointer = nil


### PR DESCRIPTION
instance-storageのほうに出したpull-reqのコピペです、文章もコードも

> mrubyの場合は、マルチスレッド動作することはないのでCRubyと違ってスレッドセーフである必要はないと思います。
> かといって、thread gemがあるので全く不可能というわけでもなく、その場合はこのmruby-delayerはthread unsafeになってしまいます。
> そもそもlock機構を削除してもいいと思うんですが、よしなに処理を分岐するコードを書いてみました
